### PR TITLE
Bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,26 +3,16 @@
 /*.log
 /target
 /release.properties
-
-# IntelliJ
-**.idea/
-**.iml
-**.ipr
-**.iws
-livingdoc-samples/target/
-\.idea/
-livingdoc-samples/livingdoc-samples\.iml
-livingdoc-cli/livingdoc-cli\.iml
-livingdoc-client/livingdoc-client\.iml
-livingdoc-core/livingdoc-core\.iml
-livingdoc-plugin/livingdoc-plugin\.iml
-
-# Eclipse
-**.settings/
-**target/
-**.project
-**.classpath
-**.eclipse-pmd
+!.gitignore
+.project
+.classpath
+.eclipse-pmd
+.idea/
+*.iml
+**/.settings/
+**/.metadata/
+**/target/
+target
 
 # /client/
 /client/deploy.bat
@@ -81,3 +71,5 @@ livingdoc-plugin/livingdoc-plugin\.iml
 # /server/src/test/resources/setupdbdatas/
 /server/src/test/resources/setupdbdatas/server.data.localhost.xml
 /server/src/test/resources/setupdbdatas/server.data.user.xml
+
+*.iml

--- a/livingdoc-core/src/main/java/info/novatec/testit/livingdoc/interpreter/collection/CollectionInterpreter.java
+++ b/livingdoc-core/src/main/java/info/novatec/testit/livingdoc/interpreter/collection/CollectionInterpreter.java
@@ -72,7 +72,7 @@ public abstract class CollectionInterpreter implements Interpreter  {
     }
 
     protected List< ? > toList(Object results) {
-        LOG.debug(ENTRY_WITH, results.toString());
+        LOG.debug(ENTRY_WITH, results);
         if (results instanceof Object[]) {
             List< ? > resultsAsList = Arrays.asList(( Object[] ) results);
             LOG.debug(EXIT_WITH, resultsAsList.toString());
@@ -83,6 +83,7 @@ public abstract class CollectionInterpreter implements Interpreter  {
             LOG.debug(EXIT_WITH, newArrayList.toString());
             return newArrayList;
         }
+        LOG.debug(EXIT_WITH, "null");
         return null;
     }
 


### PR DESCRIPTION
This occurred in one of our customer projects. The query method of a ListOf fixture failed with an exception wich resulted in a chain reaction of null cascades. All would have been well, if this logging statement would have handled null correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testit-livingdoc/livingdoc-core/61)
<!-- Reviewable:end -->
