### PR TITLE
Added gson dependency to LivingDoc-client

### DIFF
--- a/livingdoc-cli/pom.xml
+++ b/livingdoc-cli/pom.xml
@@ -39,11 +39,6 @@
 			<artifactId>slf4j-log4j12</artifactId>
 			<version>1.7.25</version>
 		</dependency>
-		<dependency>
-			<groupId>com.google.code.gson</groupId>
-			<artifactId>gson</artifactId>
-			<version>2.8.0</version>
-		</dependency>
 
 		<!-- Logging -->
 		<dependency>

--- a/livingdoc-client/pom.xml
+++ b/livingdoc-client/pom.xml
@@ -51,6 +51,11 @@
 			<version>1.9.13</version>
 		</dependency>
 		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.8.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
 			<version>4.2.5.RELEASE</version>


### PR DESCRIPTION
This dependency is using by livingdoc-cli and livingdoc-remote-agent to convert REST requests in JSON format.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testit-livingdoc/livingdoc-core/62)
<!-- Reviewable:end -->
