### PR TITLE
Disable Jdk8 Javadoc Lint by Profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,16 @@
             </build>
         </profile>
 
+        <profile>
+            <id>disable-java8-doclint</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <additionalparam>-Xdoclint:none</additionalparam>
+            </properties>
+        </profile>
+
     </profiles>
 
     <developers>


### PR DESCRIPTION
Jdk8 prevents building with javadoc errors.
Time for fixing > disabling

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testit-livingdoc/livingdoc-core/72)
<!-- Reviewable:end -->
